### PR TITLE
PRESS0-2285 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,3 @@ A Newfold module that handles integration of WordPress Solutions Addon packages 
  ```bash
  composer require newfold-labs/wp-module-solutions
  ```
-
-### 3. Setup GitHub registry
-
-Follow instructions at [GH Packages Setup](https://gist.github.com/aulisius/1a6e4961f17039d82275a6941331b021).
-
-### 4. Install the `@newfold-labs/wp-module-solutions` npm package.
-
- ```bash
- npm install @newfold-labs/wp-module-solutions
- ```

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -12,7 +12,7 @@ if ( function_exists( 'add_action' ) ) {
 			register(
 				array(
 					'name'     => 'wp-module-solutions',
-					'label'    => __( 'wp-module-solutions', 'wp-module-solutions' ),
+					'label'    => __( 'Solutions', 'wp-module-solutions' ),
 					'callback' => function ( Container $container ) {
 						new Solutions( $container );
 						define( 'NFD_SOLUTIONS_DIR', __DIR__ );

--- a/components/entitlements/EntitlementsCard.js
+++ b/components/entitlements/EntitlementsCard.js
@@ -91,30 +91,50 @@ export function EntitlementsCard(props){
                                                                             <p className="nfd-text-[#4A5567] nfd-font-normal nfd-mt-2">{__(entitlement.description, "wp-module-solutions" )}</p>                            
                                                                         </div>                
                                                                         {
-                                                                            activePluginsArray.includes(entitlement.basename) ?
+
+                                                                            entitlement.type === "plugin" ? 
+                                                                            (
+                                                                                activePluginsArray.includes(entitlement.basename) ?
+                                                                                (
+                                                                                    <Button
+                                                                                    as="a"
+                                                                                    className="nfd-button nfd-button--secondary nfd-self-center nfd-ml-auto nfd-font-normal nfd-text-[#000000]" 
+                                                                                    href={ renderCTAUrl(entitlement.cta.url) }
+                                                                                    variant="secondary"
+                                                                                    >
+                                                                                        { __(`${entitlement.cta.text}`, "wp-module-solutions") }
+                                                                                    </Button>
+                                                                                )
+                                                                                :
+                                                                                (                                                                                                                                                                                                                                                    
+                                                                                    <Button
+                                                                                    className="nfd-button nfd-button--secondary nfd-self-center nfd-ml-auto nfd-font-normal nfd-text-[#000000]" 
+                                                                                    variant="secondary"
+                                                                                    as="button" 
+                                                                                    data-nfd-installer-plugin-slug={entitlement.plsSlug !== "" ? entitlement.plsSlug : ""} 
+                                                                                    data-nfd-installer-plugin-provider={entitlement.plsProviderName !== "" ? entitlement.plsProviderName : ""} 
+                                                                                    data-nfd-installer-download-url = {  entitlement.download !== "" ? entitlement.download : "" }
+                                                                                    data-nfd-installer-plugin-activate={true}
+                                                                                    data-nfd-installer-plugin-name={entitlement.name}
+                                                                                    data-nfd-installer-plugin-url={renderCTAUrl(entitlement.cta.url)}
+                                                                                    data-nfd-installer-plugin-storage-key={entitlement.storageKey}
+                                                                                    >
+                                                                                        { __(`${entitlement.cta.text}`, "wp-module-solutions") }
+                                                                                    </Button>                                                                                                                                                                    
+                                                                                )                                                                                
+                                                                            )
+                                                                            :
                                                                             (
                                                                                 <Button
                                                                                 as="a"
                                                                                 className="nfd-button nfd-button--secondary nfd-self-center nfd-ml-auto nfd-font-normal nfd-text-[#000000]" 
-                                                                                href={ renderCTAUrl( entitlement.cta.url ) }
+                                                                                href={ renderCTAUrl(entitlement.cta.url) }
                                                                                 variant="secondary"
                                                                                 >
                                                                                     { __(`${entitlement.cta.text}`, "wp-module-solutions") }
                                                                                 </Button>
                                                                             )
-                                                                            :
-                                                                            (
-                                                                                <Button
-                                                                                className="nfd-button nfd-button--secondary nfd-self-center nfd-ml-auto nfd-font-normal nfd-text-[#000000]" 
-                                                                                variant="secondary"
-                                                                                as="button" 
-                                                                                data-nfd-installer-plugin-slug={entitlement.plsSlug} 
-                                                                                data-nfd-installer-plugin-provider={entitlement.plsProviderName} 
-                                                                                data-nfd-installer-plugin-activate={true}
-                                                                                >
-                                                                                    { __("Install", "wp-module-solutions")}
-                                                                                </Button>
-                                                                            )
+
                                                                         }       
                                                                     </div>
                                                         )

--- a/components/entitlements/EntitlementsCard.js
+++ b/components/entitlements/EntitlementsCard.js
@@ -71,7 +71,7 @@ export function EntitlementsCard(props){
                                             } 
                                             onClick={() => handleDisplay(category)}>
                                             <span className="nfd-text-[#111729] nfd-text-base nfd-font-bold">
-                                                {__(category.name, "wp-module-solutions")}
+                                                {category.name}
                                             </span>
                                             {
                                                 collapse[category.name] ? 
@@ -87,8 +87,8 @@ export function EntitlementsCard(props){
                                                                     <div className="nfd-flex nfd-flex-row nfd-pb-4 nfd-mb-4 nfd-border-b nfd-border-[#DCE2EA]" key={entitlement.slug}>                            
                                                                         <img className="entitlement-image" src={entitlement.image.primaryImage} />
                                                                         <div className="nfd-flex nfd-flex-col nfd-ml-4">
-                                                                            <h2 className="nfd-text-[#000000] nfd-font-medium">{__(entitlement.name, "wp-module-solutions")}</h2>
-                                                                            <p className="nfd-text-[#4A5567] nfd-font-normal nfd-mt-2">{__(entitlement.description, "wp-module-solutions" )}</p>                            
+                                                                            <h2 className="nfd-text-[#000000] nfd-font-medium">{entitlement.name}</h2>
+                                                                            <p className="nfd-text-[#4A5567] nfd-font-normal nfd-mt-2">{entitlement.description}</p>
                                                                         </div>                
                                                                         {
 
@@ -102,7 +102,7 @@ export function EntitlementsCard(props){
                                                                                     href={ renderCTAUrl(entitlement.cta.url) }
                                                                                     variant="secondary"
                                                                                     >
-                                                                                        { __(`${entitlement.cta.text}`, "wp-module-solutions") }
+                                                                                        {entitlement.cta.text}
                                                                                     </Button>
                                                                                 )
                                                                                 :
@@ -119,7 +119,7 @@ export function EntitlementsCard(props){
                                                                                     data-nfd-installer-plugin-url={renderCTAUrl(entitlement.cta.url)}
                                                                                     data-nfd-installer-plugin-storage-key={entitlement.storageKey}
                                                                                     >
-                                                                                        { __(`${entitlement.cta.text}`, "wp-module-solutions") }
+                                                                                        {entitlement.cta.text}
                                                                                     </Button>                                                                                                                                                                    
                                                                                 )                                                                                
                                                                             )
@@ -131,7 +131,7 @@ export function EntitlementsCard(props){
                                                                                 href={ renderCTAUrl(entitlement.cta.url) }
                                                                                 variant="secondary"
                                                                                 >
-                                                                                    { __(`${entitlement.cta.text}`, "wp-module-solutions") }
+                                                                                    {entitlement.cta.text}
                                                                                 </Button>
                                                                             )
 


### PR DESCRIPTION
## Proposed changes

Let's eliminate the "Install" and "Activate" button states and always show the CTA label on all the buttons. The URL on the buttons should be the CTA URL from the entitlements API.

Currently, we have a `{siteUrl}` placeholder in the CTA URLs returned from the Hiive entitlements API. This must be replaced with the `NewfoldRuntime.siteUrl` value to ensure the link points to the correct place.

Data attributes should be dynamically set on all the buttons as follows:

If the "type" attribute in the entitlements API is not "plugin", do not add any data attributes.
Don't set any data attributes if a plugin is installed and active. Doing so will let the button link to the destination in the href attribute.
If the plugin has a download URL in the entitlements API, then set the value of the data-nfd-installer-download-url attribute to that URL.
If the plugin has a PLS slug and provider name, set the data-nfd-installer-plugin-slug and data-nfd-installer-provider-name attributes accordingly.
Ensure no buttons have a `target="_blank"` attribute.

 

Please apply these updates to both "My Plugins & Tools" pages in the Bluehost plugin page (/wp-admin/admin.php?page=bluehost#/my_plugins_and_tools) 

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
