### PR TITLE
Fix php8.1 deprecation warning

### DIFF
--- a/includes/Solutions.php
+++ b/includes/Solutions.php
@@ -318,7 +318,7 @@ class Solutions {
 	public static function add_jetpack_menu_link() {
 
 		\add_submenu_page(
-			null, // No parent, so it won't appear in any menu
+			'', // Using empty string as parent, so it won't appear in any menu
 			'Jetpack Connection Check',
 			'',
 			'manage_options',


### PR DESCRIPTION
## Proposed changes

Passing `null` in `parent_slug` (includes/Solutions.php:321), it will generates deprecation warnings when running under PHP 8.1, because the provided `$parent_slug` is passed to `strpos()` and to `str_replace()`.

```
PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
```

This PR solves this issue replacing `null` with empty string.

## Type of Change

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
