### PR TITLE
Make the Solutions tab no longer the default "Plugins > Add New" tab

### DIFF
--- a/includes/Solutions.php
+++ b/includes/Solutions.php
@@ -287,7 +287,14 @@ class Solutions {
 			$name = ucfirst( (string) $this->container->plugin()->brand );
 		}
 		$solutions_tab = array( 'nfd_solutions' => $name . ' ' . __( 'Solutions', 'wp-module-solutions' ) );
-		return array_merge( $solutions_tab, $tabs );
+
+		// Append (not prepend) the Solutions tab so it is offered alongside the
+		// native tabs without becoming the default landing view. WordPress falls
+		// back to the first registered tab (`key( $tabs )` in
+		// WP_Plugin_Install_List_Table::prepare_items()) when no `tab` query arg
+		// is present, so prepending here replaced the native plugin
+		// search/install screen with the Solutions screen on every "Add New" click.
+		return array_merge( $tabs, $solutions_tab );
 	}
 
 	/**

--- a/tests/wpunit/SolutionsWPUnitTest.php
+++ b/tests/wpunit/SolutionsWPUnitTest.php
@@ -19,7 +19,7 @@ class SolutionsWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase {
 	 * @return void
 	 */
 	public function test_add_nfd_subnav_adds_solutions_entry() {
-		$subnav    = array();
+		$subnav = array();
 		// add_nfd_subnav calls container()->get('plugin')['id'] - we need a mock container.
 		$plugin     = new \stdClass();
 		$plugin->id = 'bluehost';
@@ -32,7 +32,7 @@ class SolutionsWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase {
 			'route'    => $brand . '#/commerce',
 			'priority' => 10,
 		);
-		$subnav[]   = $solutions;
+		$subnav[]  = $solutions;
 		$this->assertCount( 1, $subnav );
 		$this->assertSame( 'Solutions', $subnav[0]['title'] );
 		$this->assertSame( 'bluehost#/commerce', $subnav[0]['route'] );
@@ -56,10 +56,54 @@ class SolutionsWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase {
 	 * @return void
 	 */
 	public function test_addnew_brand_solutions_tab_adds_tab() {
-		$plugin         = new \stdClass();
-		$plugin->brand  = 'bluehost';
-		$plugin->id     = 'bluehost';
+		$plugin        = new \stdClass();
+		$plugin->brand = 'bluehost';
+		$plugin->id    = 'bluehost';
 		// SolutionsUpsell (created in Solutions constructor) calls container->get('capabilities')->get('canAccessGlobalCTB').
+		$capabilities = new class() {
+			/**
+			 * Stub for capabilities get (SolutionsUpsell::can_access_global_ctb).
+			 *
+			 * @param string $key Key to get.
+			 * @return bool
+			 */
+			public function get( $key ) {
+				return false;
+			}
+		};
+		$container    = $this->createMock( Container::class );
+		$container->method( 'get' )->willReturnCallback(
+			function ( $key ) use ( $plugin, $capabilities ) {
+				if ( 'plugin' === $key ) {
+					return $plugin;
+				}
+				if ( 'capabilities' === $key ) {
+					return $capabilities;
+				}
+				return null;
+			}
+		);
+		$container->method( 'plugin' )->willReturn( $plugin );
+		$solutions = new Solutions( $container );
+		$tabs      = $solutions->addnew_brand_solutions_tab( array() );
+		$this->assertArrayHasKey( 'nfd_solutions', $tabs );
+		$this->assertStringContainsString( 'Solutions', $tabs['nfd_solutions'] );
+	}
+
+	/**
+	 * Verifies addnew_brand_solutions_tab appends the Solutions tab rather than
+	 * making it the default landing tab. WordPress falls back to the first
+	 * registered tab when no `tab` query arg is present, so the Solutions tab
+	 * must not be first or it would replace the native plugin search/install
+	 * screen on every "Add New" click.
+	 *
+	 * @covers \NewfoldLabs\WP\Module\Solutions\Solutions::addnew_brand_solutions_tab
+	 * @return void
+	 */
+	public function test_addnew_brand_solutions_tab_is_not_default() {
+		$plugin        = new \stdClass();
+		$plugin->brand = 'bluehost';
+		$plugin->id    = 'bluehost';
 		$capabilities  = new class() {
 			/**
 			 * Stub for capabilities get (SolutionsUpsell::can_access_global_ctb).
@@ -84,9 +128,12 @@ class SolutionsWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCase {
 			}
 		);
 		$container->method( 'plugin' )->willReturn( $plugin );
-		$solutions     = new Solutions( $container );
-		$tabs           = $solutions->addnew_brand_solutions_tab( array() );
+		$solutions = new Solutions( $container );
+
+		$tabs = $solutions->addnew_brand_solutions_tab( array( 'featured' => 'Featured' ) );
+
+		// Native tab stays first (the default landing view); Solutions is offered, appended.
+		$this->assertSame( 'featured', array_key_first( $tabs ) );
 		$this->assertArrayHasKey( 'nfd_solutions', $tabs );
-		$this->assertStringContainsString( 'Solutions', $tabs['nfd_solutions'] );
 	}
 }


### PR DESCRIPTION
https://newfold.atlassian.net/browse/PRESS0-4650

## Proposed changes

On WP Admin → Plugins → Add New, customers were landing on the **Bluehost Solutions** promotional tab instead of the native WordPress plugin search/install screen. Installing a plugin is one of the highest-frequency things a customer does, so replacing that screen with a promo undercuts trust on a near-universal path.

**Root cause:** the Solutions tab is registered via the `install_plugins_tabs` filter and was *prepended* to the tab list (`array_merge( $solutions_tab, $tabs )`). WordPress core (`WP_Plugin_Install_List_Table::prepare_items()`) falls back to the first registered tab (`key( $tabs )`) when no `tab` query argument is present, so prepending made Solutions the default landing view and effectively replaced the native screen.

**Fix:** append the Solutions tab instead (`array_merge( $tabs, $solutions_tab )`). The tab stays fully available; WordPress's native "Featured" screen is restored as the default landing view. This matches how the Marketplace "Premium" tab already behaves — it appends and never hijacks the default.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Visual

**Before:** clicking Plugins → Add New opened the Bluehost Solutions tab in place of the plugin search.

**After:** clicking Plugins → Add New opens the native Featured plugin search; the Solutions tab remains available alongside Featured / Popular / Recommended / Favorites.

Verified on a live site that the default landing tab resolves to `featured` while `nfd_solutions` is still present in the tab list.

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests pass (`composer run test` — wpunit).
- [x] My code follows the code style of this project (`composer run lint` — phpcs clean on changed files).

## Further comments

The change is a single line in `includes/Solutions.php` plus a regression test (`test_addnew_brand_solutions_tab_is_not_default`) that asserts a native tab stays first and the Solutions tab is still present. The Solutions tab itself is unchanged and still reachable; only its position — and therefore the default landing tab — changes.
