### PR TITLE
PRESS0-4671: Keep Bluehost brand name untranslated in all locales

### DIFF
--- a/languages/wp-module-solutions-es_ES.l10n.php
+++ b/languages/wp-module-solutions-es_ES.l10n.php
@@ -12,7 +12,7 @@ return [
 		'Activated the plugin successfully!' => '¡Se ha activado el plugin con éxito!',
 		'Please send valid plugin' => 'Por favor, envíe un plugin válido',
 		'My Solution' => 'Mi solución',
-		'Bluehost' => 'Presentador azul',
+		'Bluehost' => 'Bluehost',
 		'HostGator' => 'HostGator',
 		'Solution Upsell product type labelBookable product' => 'Producto que se puede reservar',
 		'Solution Upsell product type labelGift card' => 'Tarjeta de regalo',

--- a/languages/wp-module-solutions-es_ES.po
+++ b/languages/wp-module-solutions-es_ES.po
@@ -40,7 +40,7 @@ msgstr "Mi solución"
 
 #: includes/SolutionsBranding.php:116
 msgid "Bluehost"
-msgstr "Presentador azul"
+msgstr "Bluehost"
 
 #: includes/SolutionsBranding.php:117
 msgid "HostGator"

--- a/languages/wp-module-solutions-es_MX.l10n.php
+++ b/languages/wp-module-solutions-es_MX.l10n.php
@@ -12,7 +12,7 @@ return [
 		'Activated the plugin successfully!' => '¡El plugin se activó correctamente!',
 		'Please send valid plugin' => 'Por favor, envía un plugin válido',
 		'My Solution' => 'Mi solución',
-		'Bluehost' => 'Presentador azul',
+		'Bluehost' => 'Bluehost',
 		'HostGator' => 'HostGator',
 		'Solution Upsell product type labelBookable product' => 'Producto que se puede reservar',
 		'Solution Upsell product type labelGift card' => 'Tarjeta de regalo',

--- a/languages/wp-module-solutions-es_MX.po
+++ b/languages/wp-module-solutions-es_MX.po
@@ -35,7 +35,7 @@ msgstr "Mi solución"
 
 #: includes/SolutionsBranding.php:116
 msgid "Bluehost"
-msgstr "Presentador azul"
+msgstr "Bluehost"
 
 #: includes/SolutionsBranding.php:117
 msgid "HostGator"

--- a/languages/wp-module-solutions-fr_FR.l10n.php
+++ b/languages/wp-module-solutions-fr_FR.l10n.php
@@ -12,7 +12,7 @@ return [
 		'Activated the plugin successfully!' => 'Le plugin a été activé avec succès !',
 		'Please send valid plugin' => 'Veuillez envoyer un plugin valide',
 		'My Solution' => 'Ma solution',
-		'Bluehost' => 'Hôte bleu',
+		'Bluehost' => 'Bluehost',
 		'HostGator' => 'HostGator',
 		'Solution Upsell product type labelBookable product' => 'Produit réservable',
 		'Solution Upsell product type labelGift card' => 'Carte cadeau',

--- a/languages/wp-module-solutions-fr_FR.po
+++ b/languages/wp-module-solutions-fr_FR.po
@@ -40,7 +40,7 @@ msgstr "Ma solution"
 
 #: includes/SolutionsBranding.php:116
 msgid "Bluehost"
-msgstr "Hôte bleu"
+msgstr "Bluehost"
 
 #: includes/SolutionsBranding.php:117
 msgid "HostGator"

--- a/languages/wp-module-solutions-pt_BR.l10n.php
+++ b/languages/wp-module-solutions-pt_BR.l10n.php
@@ -12,7 +12,7 @@ return [
 		'Activated the plugin successfully!' => 'Plugin ativado com sucesso!',
 		'Please send valid plugin' => 'Por favor, envie um plugin válido',
 		'My Solution' => 'Minha Solução',
-		'Bluehost' => 'Hospedeiro azul',
+		'Bluehost' => 'Bluehost',
 		'HostGator' => 'HostGator',
 		'Solution Upsell product type labelBookable product' => 'Produto reservável',
 		'Solution Upsell product type labelGift card' => 'Cartão-presente',

--- a/languages/wp-module-solutions-pt_BR.po
+++ b/languages/wp-module-solutions-pt_BR.po
@@ -35,7 +35,7 @@ msgstr "Minha Solução"
 
 #: includes/SolutionsBranding.php:116
 msgid "Bluehost"
-msgstr "Hospedeiro azul"
+msgstr "Bluehost"
 
 #: includes/SolutionsBranding.php:117
 msgid "HostGator"


### PR DESCRIPTION
## Summary
- Revert incorrect Spanish (es_ES, es_MX), French (fr_FR), and Brazilian Portuguese (pt_BR) translations of the "Bluehost" proper noun
- Ensure `msgstr` for "Bluehost" is exactly "Bluehost" in all affected `.po` and `.l10n.php` files, consistent with how HostGator is handled

## Jira
https://newfold.atlassian.net/browse/PRESS0-4671

## Test plan
- [ ] Verify `languages/wp-module-solutions-es_ES.*`, `es_MX.*`, `fr_FR.*`, and `pt_BR.*` show `Bluehost` => `Bluehost`
- [ ] Confirm HostGator translations remain unchanged
- [ ] Smoke test Solutions UI in es_ES / fr_FR locale if possible