### PR TITLE
Point Bluehost eCom family CTA to marketplace URL (PRESS0-4701)

### DIFF
--- a/includes/SolutionsBranding.php
+++ b/includes/SolutionsBranding.php
@@ -188,7 +188,7 @@ class SolutionsBranding {
 				'ctbs'   => array(
 					'ecomFamily' => array(
 						'id'  => self::DEFAULT_ECOM_FAMILY_CTB_ID,
-						'url' => 'https://www.bluehost.com/my-account/hosting/details#click-to-buy-WP_SOLUTION_FAMILY',
+						'url' => 'https://www.bluehost.com/my-account/market-place#marketplace-WordPress%20Solutions',
 					),
 				),
 				'colors' => array(

--- a/tests/playwright/helpers/index.mjs
+++ b/tests/playwright/helpers/index.mjs
@@ -519,6 +519,54 @@ async function verifyHrefContainsAfterUtm(button, expected) {
 }
 
 /**
+ * Assert an eCom-family upsell CTA points at the brand's localized
+ * `ctbs.ecomFamily.url`, with link-tracker UTM params injected before the
+ * fragment and the fragment preserved.
+ *
+ * Brand-agnostic: derives the expected destination from the localized branding
+ * instead of hardcoding a path, so it stays correct across brands and future
+ * destination changes.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {import('@playwright/test').Locator} button
+ */
+async function verifyEcomFamilyCtaHref(page, button) {
+  const branding = await readNewfoldSolutionsBranding(page);
+  const ctbUrl = branding?.ctbs?.ecomFamily?.url;
+  expect(typeof ctbUrl).toBe('string');
+  expect(ctbUrl.length).toBeGreaterThan(0);
+
+  const [ctbBase, ctbFragment] = ctbUrl.split('#');
+
+  // The link tracker rewrites the href shortly after mount; poll until UTM params land.
+  await expect
+    .poll(async () => button.getAttribute('href'), {
+      timeout: 5000,
+      intervals: [100, 250, 500],
+    })
+    .toContain('utm_medium=');
+
+  const href = await button.getAttribute('href');
+
+  // Base path is preserved (whatever the backend localized for this brand).
+  expect(href.startsWith(ctbBase)).toBeTruthy();
+
+  // Tracking params are appended by the link tracker.
+  for (const param of ['channelid=', 'utm_source=', 'utm_medium=']) {
+    expect(href).toContain(param);
+  }
+
+  // Params are inserted before the fragment, and the fragment is preserved at the end.
+  if (ctbFragment) {
+    expect(href.endsWith(`#${ctbFragment}`)).toBeTruthy();
+    const queryIndex = href.indexOf('?');
+    const fragmentIndex = href.indexOf('#');
+    expect(queryIndex).toBeGreaterThan(-1);
+    expect(queryIndex).toBeLessThan(fragmentIndex);
+  }
+}
+
+/**
  * Assert CTB purchase buttons expose the expected click-to-buy id (href optional).
  *
  * @param {import('@playwright/test').Locator} button
@@ -622,6 +670,7 @@ export {
   verifyMissingAttributes,
   verifyHrefContains,
   verifyHrefContainsAfterUtm,
+  verifyEcomFamilyCtaHref,
   verifyCtbButton,
   clickInstallAndVerifyModal,
   verifyPluginInstalled,

--- a/tests/playwright/specs/addnew-entitlements.spec.mjs
+++ b/tests/playwright/specs/addnew-entitlements.spec.mjs
@@ -8,7 +8,7 @@ import {
   verifyInstallerAttributes,
   verifyMissingAttributes,
   verifyHrefContains,
-  verifyHrefContainsAfterUtm,
+  verifyEcomFamilyCtaHref,
 } from '../helpers/index.mjs';
 
 test.describe('My Solutions on Plugin Install Page - Entitlements Check', () => {
@@ -61,11 +61,11 @@ test.describe('My Solutions on Plugin Install Page - Entitlements Check', () => 
 
     const upgradeButton = page.locator(SELECTORS.mySolutionsUpgradeBannerButton);
     await expect(upgradeButton).toBeVisible();
-    await verifyHrefContainsAfterUtm(
-      upgradeButton,
-      '#click-to-buy-WP_SOLUTION_FAMILY'
-    );
     await expect(upgradeButton).toHaveAttribute('data-ctb-id', CTB_IDS.solutionFamily);
+
+    // Brand-agnostic: assert the href resolves to the localized eCom family URL
+    // with UTM params injected before the (preserved) fragment.
+    await verifyEcomFamilyCtaHref(page, upgradeButton);
 
     const advReviewsTitle = page.locator(SELECTORS.pluginCardTitle('advanced-reviews'));
     await expect(advReviewsTitle).toContainText('Advanced Reviews');

--- a/tests/playwright/specs/solutions-page.spec.mjs
+++ b/tests/playwright/specs/solutions-page.spec.mjs
@@ -8,6 +8,7 @@ import {
   verifyInstallerAttributes,
   verifyMissingAttributes,
   verifyHrefContains,
+  readNewfoldSolutionsBranding,
 } from '../helpers/index.mjs';
 
 const pluginId = process.env.PLUGIN_ID || 'bluehost';
@@ -38,7 +39,7 @@ test.describe('Solutions App in plugin', () => {
     await expect(bannerTitle).toBeVisible();
   });
 
-  test('Solutions page displays upgrade with CTB atts for those with no solution', async ({ page }) => {
+  test('Solutions page upgrade CTA targets the localized eCom family URL with UTM params preserved across the fragment', async ({ page }) => {
     const pre = await setSolutionAndOpenSolutionsPage(page, 'none', pluginId, 'none');
     test.skip(!pre.ok, pre.reason);
 
@@ -53,9 +54,48 @@ test.describe('Solutions App in plugin', () => {
     await bannerTitle.scrollIntoViewIfNeeded();
     await expect(bannerTitle).toBeVisible();
 
+    // Source of truth: the eCom family URL the backend localized for THIS brand.
+    // Asserting against it (rather than a hardcoded path) keeps the test brand-agnostic
+    // and resilient to future destination changes.
+    const branding = await readNewfoldSolutionsBranding(page);
+    const ctbUrl = branding?.ctbs?.ecomFamily?.url;
+    expect(typeof ctbUrl).toBe('string');
+    expect(ctbUrl.length).toBeGreaterThan(0);
+
+    const [ctbBase, ctbFragment] = ctbUrl.split('#');
+
     const upgradeButton = page.locator(SELECTORS.upgradeBannerButton);
-    await verifyHrefContains(upgradeButton, '#click-to-buy-WP_SOLUTION_FAMILY');
+    await expect(upgradeButton).toBeVisible();
+
+    // The CTB id stays on the button regardless of the destination URL.
     await expect(upgradeButton).toHaveAttribute('data-ctb-id', CTB_IDS.solutionFamily);
+
+    // The link tracker rewrites the href shortly after mount; poll until UTM params land.
+    await expect
+      .poll(async () => upgradeButton.getAttribute('href'), {
+        timeout: 5000,
+        intervals: [100, 250, 500],
+      })
+      .toContain('utm_medium=');
+
+    const href = await upgradeButton.getAttribute('href');
+
+    // Base path is preserved (whatever the backend provided for this brand).
+    expect(href.startsWith(ctbBase)).toBeTruthy();
+
+    // Tracking params are appended by the link tracker.
+    for (const param of ['channelid=', 'utm_source=', 'utm_medium=']) {
+      expect(href).toContain(param);
+    }
+
+    // Params are inserted before the fragment, and the fragment is preserved at the end.
+    if (ctbFragment) {
+      expect(href.endsWith(`#${ctbFragment}`)).toBeTruthy();
+      const queryIndex = href.indexOf('?');
+      const fragmentIndex = href.indexOf('#');
+      expect(queryIndex).toBeGreaterThan(-1);
+      expect(queryIndex).toBeLessThan(fragmentIndex);
+    }
   });
 
   test('Creator solutions page displays tools with proper button atts', async ({ page }) => {

--- a/tests/playwright/specs/solutions-page.spec.mjs
+++ b/tests/playwright/specs/solutions-page.spec.mjs
@@ -8,7 +8,7 @@ import {
   verifyInstallerAttributes,
   verifyMissingAttributes,
   verifyHrefContains,
-  readNewfoldSolutionsBranding,
+  verifyEcomFamilyCtaHref,
 } from '../helpers/index.mjs';
 
 const pluginId = process.env.PLUGIN_ID || 'bluehost';
@@ -54,48 +54,15 @@ test.describe('Solutions App in plugin', () => {
     await bannerTitle.scrollIntoViewIfNeeded();
     await expect(bannerTitle).toBeVisible();
 
-    // Source of truth: the eCom family URL the backend localized for THIS brand.
-    // Asserting against it (rather than a hardcoded path) keeps the test brand-agnostic
-    // and resilient to future destination changes.
-    const branding = await readNewfoldSolutionsBranding(page);
-    const ctbUrl = branding?.ctbs?.ecomFamily?.url;
-    expect(typeof ctbUrl).toBe('string');
-    expect(ctbUrl.length).toBeGreaterThan(0);
-
-    const [ctbBase, ctbFragment] = ctbUrl.split('#');
-
     const upgradeButton = page.locator(SELECTORS.upgradeBannerButton);
     await expect(upgradeButton).toBeVisible();
 
     // The CTB id stays on the button regardless of the destination URL.
     await expect(upgradeButton).toHaveAttribute('data-ctb-id', CTB_IDS.solutionFamily);
 
-    // The link tracker rewrites the href shortly after mount; poll until UTM params land.
-    await expect
-      .poll(async () => upgradeButton.getAttribute('href'), {
-        timeout: 5000,
-        intervals: [100, 250, 500],
-      })
-      .toContain('utm_medium=');
-
-    const href = await upgradeButton.getAttribute('href');
-
-    // Base path is preserved (whatever the backend provided for this brand).
-    expect(href.startsWith(ctbBase)).toBeTruthy();
-
-    // Tracking params are appended by the link tracker.
-    for (const param of ['channelid=', 'utm_source=', 'utm_medium=']) {
-      expect(href).toContain(param);
-    }
-
-    // Params are inserted before the fragment, and the fragment is preserved at the end.
-    if (ctbFragment) {
-      expect(href.endsWith(`#${ctbFragment}`)).toBeTruthy();
-      const queryIndex = href.indexOf('?');
-      const fragmentIndex = href.indexOf('#');
-      expect(queryIndex).toBeGreaterThan(-1);
-      expect(queryIndex).toBeLessThan(fragmentIndex);
-    }
+    // Brand-agnostic: assert the href resolves to the localized eCom family URL
+    // with UTM params injected before the (preserved) fragment.
+    await verifyEcomFamilyCtaHref(page, upgradeButton);
   });
 
   test('Creator solutions page displays tools with proper button atts', async ({ page }) => {

--- a/tests/wpunit/SolutionsBrandingWPUnitTest.php
+++ b/tests/wpunit/SolutionsBrandingWPUnitTest.php
@@ -89,6 +89,53 @@ class SolutionsBrandingWPUnitTest extends \lucatume\WPBrowser\TestCase\WPTestCas
 	}
 
 	/**
+	 * Bluehost eCom family CTB (Discover Now CTA) should target the marketplace
+	 * WordPress Solutions section, keep the shared CTB id, and survive URL
+	 * sanitization with the encoded fragment intact (PRESS0-4701).
+	 *
+	 * @return void
+	 */
+	public function test_bluehost_ecom_family_ctb_points_to_marketplace() {
+		$plugin        = new \stdClass();
+		$plugin->id    = 'bluehost';
+		$plugin->brand = 'bluehost';
+
+		$container = $this->branding_container_mock( $plugin );
+		$branding  = SolutionsBranding::build_for_container( $container );
+
+		$this->assertSame(
+			'https://www.bluehost.com/my-account/market-place#marketplace-WordPress%20Solutions',
+			$branding['ctbs']['ecomFamily']['url'] ?? null,
+			'Bluehost Discover Now CTA should point to the marketplace WordPress Solutions section with the encoded fragment preserved.'
+		);
+		$this->assertSame(
+			SolutionsBranding::DEFAULT_ECOM_FAMILY_CTB_ID,
+			$branding['ctbs']['ecomFamily']['id'] ?? null,
+			'The shared eCom family CTB id should be unchanged.'
+		);
+	}
+
+	/**
+	 * The Bluehost marketplace retarget must not leak into the HostGator preset,
+	 * which keeps its own click-to-buy destination (PRESS0-4701).
+	 *
+	 * @return void
+	 */
+	public function test_hostgator_ecom_family_ctb_unaffected_by_bluehost_retarget() {
+		$plugin        = new \stdClass();
+		$plugin->id    = 'hostgator';
+		$plugin->brand = 'hostgator';
+
+		$container = $this->branding_container_mock( $plugin );
+		$branding  = SolutionsBranding::build_for_container( $container );
+
+		$url = $branding['ctbs']['ecomFamily']['url'] ?? '';
+		$this->assertStringContainsString( 'hostgator.com', $url );
+		$this->assertStringContainsString( 'click-to-buy-WP_SOLUTION_FAMILY', $url );
+		$this->assertStringNotContainsString( 'market-place', $url );
+	}
+
+	/**
 	 * Bluehost preset should expose a module wordmark URL (static SVG file).
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary

Updates the Bluehost `ctbs.ecomFamily` branding URL so the **Discover Now** CTA on the commerce page points to the marketplace WordPress Solutions section instead of the click-to-buy hosting details page.

- **New URL:** `https://www.bluehost.com/my-account/market-place#marketplace-WordPress%20Solutions`
- The CTB id (`DEFAULT_ECOM_FAMILY_CTB_ID`) is unchanged.
- **HostGator branding is untouched.**
- UTM params (`channelid`, `utm_source`, `utm_medium`) are still appended at click-time by the link tracker, so tracking is preserved.

This is the branding value that takes precedence over the host plugin's runtime fallback, so it is what actually drives the CTA href. Companion change in the Bluehost plugin keeps its runtime fallback consistent.

## Ticket

PRESS0-4701