### PR TITLE
Use clear installer queue helper

### DIFF
--- a/tests/playwright/helpers/index.mjs
+++ b/tests/playwright/helpers/index.mjs
@@ -23,6 +23,7 @@ const pluginHelpers = await import(helpersUrl);
 // Destructure plugin helpers
 let { auth, wordpress, newfold, a11y, utils } = pluginHelpers;
 const { fancyLog } = utils;
+const clearInstallerQueues = newfold.clearInstallerQueues;
 
 // Load solution fixtures
 const fixturesPath = join(__dirname, '../fixtures');
@@ -660,6 +661,7 @@ export {
   setSolutionAndOpenMySolutions,
   setSolutionAndOpenSolutionsPage,
   clearSolutionTransient,
+  clearInstallerQueues,
   uninstallPlugin,
   // Navigation helpers
   navigateToSolutionsPage,

--- a/tests/playwright/helpers/index.mjs
+++ b/tests/playwright/helpers/index.mjs
@@ -24,6 +24,13 @@ const pluginHelpers = await import(helpersUrl);
 let { auth, wordpress, newfold, a11y, utils } = pluginHelpers;
 const { fancyLog } = utils;
 const clearInstallerQueues = newfold.clearInstallerQueues;
+const ensurePluginInactive = newfold.ensurePluginInactive;
+
+// Plugins whose pre-install UI this module asserts, so specs can state the precondition
+// they depend on rather than inheriting it from global setup or a sibling spec.
+const TOOL_PLUGINS = {
+  yoastSeo: { slug: 'wordpress-seo', basename: 'wordpress-seo/wp-seo.php' },
+};
 
 // Load solution fixtures
 const fixturesPath = join(__dirname, '../fixtures');
@@ -378,17 +385,33 @@ async function clearSolutionTransient() {
 
 /**
  * Uninstall a plugin
- * 
+ *
+ * Runs on the default WP-CLI timeout. A short override used to kill this partway through:
+ * `npx wp-env run cli` spends several seconds starting the container before WP-CLI even
+ * runs, so uninstalling a large plugin could time out, leave it installed and active, and
+ * hand that state to the next spec.
+ *
  * @param {string} pluginSlug - Plugin slug to uninstall
+ * @returns {Promise<{ok: boolean, reason: string}>}
  */
 async function uninstallPlugin(pluginSlug) {
   try {
-    await wordpress.wpCli(`plugin uninstall ${pluginSlug} --deactivate`, {
-      timeout: 15000,
-      failOnNonZeroExit: false,
-    });
+    const result = await wordpress.wpCli(
+      `plugin uninstall ${pluginSlug} --deactivate`,
+      { failOnNonZeroExit: false }
+    );
+
+    if (wordpress.isWpCliFailure(result)) {
+      const reason = `Failed to uninstall ${pluginSlug}: ${wordpress.formatWpCliResult(result)}`;
+      fancyLog(reason, 55, 'yellow');
+      return { ok: false, reason };
+    }
+
+    return { ok: true, reason: '' };
   } catch (error) {
-    fancyLog(`Failed to uninstall ${pluginSlug}: ${error.message}`, 55, 'yellow');
+    const reason = `Failed to uninstall ${pluginSlug}: ${error.message}`;
+    fancyLog(reason, 55, 'yellow');
+    return { ok: false, reason };
   }
 }
 
@@ -653,6 +676,7 @@ export {
   E2E_TEST_IDS,
   CTB_IDS,
   FIXTURES,
+  TOOL_PLUGINS,
   // Solution helpers
   setSolution,
   verifySolutionTransient,
@@ -662,6 +686,7 @@ export {
   setSolutionAndOpenSolutionsPage,
   clearSolutionTransient,
   clearInstallerQueues,
+  ensurePluginInactive,
   uninstallPlugin,
   // Navigation helpers
   navigateToSolutionsPage,

--- a/tests/playwright/specs/solutions-page.spec.mjs
+++ b/tests/playwright/specs/solutions-page.spec.mjs
@@ -3,9 +3,11 @@ import {
   auth,
   clearInstallerQueues,
   clearSolutionTransient,
+  ensurePluginInactive,
   setSolutionAndOpenSolutionsPage,
   SELECTORS,
   CTB_IDS,
+  TOOL_PLUGINS,
   verifyInstallerAttributes,
   verifyMissingAttributes,
   verifyHrefContains,
@@ -16,11 +18,20 @@ const pluginId = process.env.PLUGIN_ID || 'bluehost';
 
 test.describe('Solutions App in plugin', () => {
 
+  // The tool card assertions below describe Yoast SEO's *pre-install* state: a download URL
+  // and an install action. If Yoast is active the card renders "Configure" with no download
+  // URL, and those assertions fail on an empty attribute rather than on anything this module
+  // owns. Rather than inherit that precondition from global setup or a sibling spec, this
+  // file establishes and verifies it itself.
+  let yoastInactive = { ok: false, reason: 'precondition not evaluated' };
+
   test.beforeAll(async () => {
+    // Drop any queued installs first, so nothing re-activates Yoast between tests.
     await clearInstallerQueues();
   });
 
   test.beforeEach(async ({ page }) => {
+    yoastInactive = await ensurePluginInactive(TOOL_PLUGINS.yoastSeo.basename);
     await auth.loginToWordPress(page);
   });
 
@@ -89,6 +100,8 @@ test.describe('Solutions App in plugin', () => {
     await yoastTitle.scrollIntoViewIfNeeded();
     await expect(yoastTitle).toBeVisible();
 
+    expect(yoastInactive.ok, yoastInactive.reason).toBe(true);
+
     const yoastButton = page.locator(SELECTORS.toolCardButton('yoast-seo'));
     await verifyInstallerAttributes(yoastButton, {
       downloadUrl: 'https://downloads.wordpress.org/plugin/wordpress-seo.latest-stable.zip',
@@ -148,6 +161,8 @@ test.describe('Solutions App in plugin', () => {
     await expect(yoastTitle).toContainText('Yoast SEO');
     await yoastTitle.scrollIntoViewIfNeeded();
     await expect(yoastTitle).toBeVisible();
+
+    expect(yoastInactive.ok, yoastInactive.reason).toBe(true);
 
     const yoastButton = page.locator(SELECTORS.toolCardButton('yoast-seo'));
     await verifyInstallerAttributes(yoastButton, {
@@ -213,6 +228,8 @@ test.describe('Solutions App in plugin', () => {
     await expect(yoastCard).toBeVisible();
     const yoastTitle = page.locator(SELECTORS.toolCardTitle('yoast-seo'));
     await expect(yoastTitle).toContainText('Yoast SEO');
+
+    expect(yoastInactive.ok, yoastInactive.reason).toBe(true);
 
     const yoastButton = page.locator(SELECTORS.toolCardButton('yoast-seo'));
     await verifyInstallerAttributes(yoastButton, {

--- a/tests/playwright/specs/solutions-page.spec.mjs
+++ b/tests/playwright/specs/solutions-page.spec.mjs
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import {
   auth,
+  clearInstallerQueues,
   clearSolutionTransient,
   setSolutionAndOpenSolutionsPage,
   SELECTORS,
@@ -14,6 +15,10 @@ import {
 const pluginId = process.env.PLUGIN_ID || 'bluehost';
 
 test.describe('Solutions App in plugin', () => {
+
+  test.beforeAll(async () => {
+    await clearInstallerQueues();
+  });
 
   test.beforeEach(async ({ page }) => {
     await auth.loginToWordPress(page);


### PR DESCRIPTION
## Proposed changes

Use a new plugin-based helper to clear the installer queue and ensure third-party plugins are inactive to fix flaky tests. (only on bluehost develop so far)
_

The onboarding spec's beforeAll calls resetOnboardingState(), which deletes nfd_module_onboarding_status. That makes StatusService::handle_started() return true again on the next app boot, so AppService::start() re-seeds the queue. resetOnboardingState() never clears the installer queues it caused to be filled.

Onboarding project (tests 124–130): 08:32:22 → 08:33:00 — queue gets seeded here
Solutions project starts: ~08:34:59
addnew-yoast install test: 08:35:34
solutions-page tests: ~08:36+
Queue order is highest-priority-first: optinmonster (290), google-analytics (280), wpforms-lite (270), wordpress-seo (260), jetpack (250), endurance-page-cache (240). At ~30s per tick, Yoast's install+activate lands roughly 2 minutes after seeding — i.e. squarely inside the Solutions project, within about a minute of the boundary between addnew-yoast and solutions-page.

addnew-yoast.spec.mjs uninstalls Yoast in beforeEach, so if the cron fires before those tests it gets cleaned up and everything passes. If it fires after — during solutions-branding or solutions-page — Yoast is installed and activated behind the browser's back and all three solutions-page Yoast assertions fail as a block.

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Visual

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- On macOS press cmd+shift+3 to screenshot the entire screen, or cmd+shift+4 to select an area to capture -->
<!-- The screenshot will be saved to the desktop -->

<!-- Drag and drop the file(s) into the GitHub editor to attach -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->