### PR TITLE
Tag Playwright tests for @env-any and @env-local

### DIFF
--- a/tests/playwright/specs/addnew-entitlements.spec.mjs
+++ b/tests/playwright/specs/addnew-entitlements.spec.mjs
@@ -11,7 +11,7 @@ import {
   verifyEcomFamilyCtaHref,
 } from '../helpers/index.mjs';
 
-test.describe('My Solutions on Plugin Install Page - Entitlements Check', () => {
+test.describe('My Solutions on Plugin Install Page - Entitlements Check', { tag: '@env-local' }, () => {
 
   test.beforeEach(async ({ page }) => {
     await auth.loginToWordPress(page);

--- a/tests/playwright/specs/addnew-jetpack.spec.mjs
+++ b/tests/playwright/specs/addnew-jetpack.spec.mjs
@@ -20,7 +20,7 @@ import {
 let jetpackSupported = false;
 let jetpackSkipMessage = '';
 
-test.describe('My Solutions on Plugin Install Page - Jetpack Plugin', () => {
+test.describe('My Solutions on Plugin Install Page - Jetpack Plugin', { tag: '@env-local' }, () => {
 
   test.beforeAll(async () => {
     jetpackSupported = await newfold.supportsJetpack();

--- a/tests/playwright/specs/addnew-my-solutions.spec.mjs
+++ b/tests/playwright/specs/addnew-my-solutions.spec.mjs
@@ -7,7 +7,15 @@ import {
   SELECTORS,
 } from '../helpers/index.mjs';
 
-test.describe('My Solutions on Plugin Install Page', () => {
+test.describe('My Solutions on Plugin Install Page (env-any)', { tag: '@env-any' }, () => {
+  test('Solutions tab is present on plugin-install', async ({ page }) => {
+    await auth.navigateToAdminPage(page, 'plugin-install.php');
+    const tab = page.locator('.plugin-install-nfd_solutions, a[href*="tab=nfd_solutions"]');
+    await expect(tab.first()).toBeVisible({ timeout: 15000 });
+  });
+});
+
+test.describe('My Solutions on Plugin Install Page', { tag: '@env-local' }, () => {
 
   test.beforeEach(async ({ page }) => {
     await auth.loginToWordPress(page);

--- a/tests/playwright/specs/addnew-yoast.spec.mjs
+++ b/tests/playwright/specs/addnew-yoast.spec.mjs
@@ -20,7 +20,7 @@ import {
 let yoastSupported = false;
 let yoastSkipMessage = '';
 
-test.describe('My Solutions on Plugin Install Page - Yoast Check', () => {
+test.describe('My Solutions on Plugin Install Page - Yoast Check', { tag: '@env-local' }, () => {
 
   test.beforeAll(async () => {
     yoastSupported = await newfold.supportsYoast();

--- a/tests/playwright/specs/solutions-branding.spec.mjs
+++ b/tests/playwright/specs/solutions-branding.spec.mjs
@@ -17,7 +17,7 @@ function isWordmarkUnset(value) {
   return value === undefined || value === null || value === false || value === '';
 }
 
-test.describe('Solutions page branding', () => {
+test.describe('Solutions page branding', { tag: '@env-local' }, () => {
   test.beforeEach(async ({ page }) => {
     await auth.loginToWordPress(page);
   });

--- a/tests/playwright/specs/solutions-page.spec.mjs
+++ b/tests/playwright/specs/solutions-page.spec.mjs
@@ -16,7 +16,18 @@ import {
 
 const pluginId = process.env.PLUGIN_ID || 'bluehost';
 
-test.describe('Solutions App in plugin', () => {
+test.describe('Solutions App in plugin (env-any)', { tag: '@env-any' }, () => {
+  test('Commerce solutions route renders', async ({ page }) => {
+    await auth.navigateToAdminPage(page, `admin.php?page=${pluginId}#/commerce`);
+    await page.waitForSelector('#wppbh-app-rendered, .nfd-page-solutions, .wppbh-app-body', {
+      timeout: 15000,
+    });
+    const hash = await page.evaluate(() => window.location.hash);
+    expect(hash).toMatch(/commerce/);
+  });
+});
+
+test.describe('Solutions App in plugin', { tag: '@env-local' }, () => {
 
   // The tool card assertions below describe Yoast SEO's *pre-install* state: a download URL
   // and an install action. If Yoast is active the card renders "Configure" with no download


### PR DESCRIPTION
## Summary
- Adds opt-in `@env-any` smoke tests that do not use WP-CLI: commerce route renders, and the Solutions tab is present on plugin-install.
- Tags CLI/fixture/installer specs `@env-local` so they stay out of Playground and live-site runs.

This matches the env tag convention from [wp-plugin-bluehost#1121](https://github.com/newfold-labs/wp-plugin-bluehost/pull/1121). Branched from current `main` (`828900d`).

## Test plan
- [ ] Confirm `npx playwright test --grep @env-any --project newfold-labs/wp-module-solutions` lists only the two new layout tests
- [ ] Confirm local/wp-env suite still runs the `@env-local` describes
- [ ] Optional: run the two `@env-any` tests against Playground or a `BASE_URL` without wp-env


Made with [Cursor](https://cursor.com)